### PR TITLE
Update for conda-recipe

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,5 +29,4 @@ about:
   license: GPLv3
   license_file: LICENSE
   summary: Python library for estimating linear moments for statistical distributions
-#  readme: README.rst
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -29,5 +29,5 @@ about:
   license: GPLv3
   license_file: LICENSE
   summary: Python library for estimating linear moments for statistical distributions
-  readme: README.rst
+#  readme: README.rst
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -12,13 +12,13 @@ requirements:
   build:
     - python
     - setuptools
-    - numpy 1.9*
-    - scipy >=0.14
+    - numpy
+    - scipy
 
   run:
     - python
-    - numpy 1.9*
-    - scipy >=0.14
+    - numpy
+    - scipy
 
 test:
   imports:


### PR DESCRIPTION
Using the modified `meta.yaml` file I was able to install lmoments3 into my local Anaconda environment using the following approach:
```
$ conda-build conda-recipe
$ conda install --use-local lmoments3
```
Note: The environment's Python version was 3.7 before this, and the above lmoments3 local install dropped the Python version down to 3.6.6.