### PR TITLE
Adapt to changes in scipy 1.9

### DIFF
--- a/lmoments3/distr.py
+++ b/lmoments3/distr.py
@@ -26,6 +26,14 @@ import math
 import lmoments3 as lm
 
 
+try:
+    # Scipy >= 1.9
+    from scipy.stats._distn_infrastructure import rv_continuous_frozen
+except ImportError:
+    # Scipy < 1.9
+    from scipy.stats._distn_infrastructure import rv_frozen as rv_continuous_frozen
+
+
 class LmomDistrMixin(object):
     """
     Mixin class to add L-moment methods to :class:`scipy.stats.rv_continous` distribution functions. Distributions using
@@ -123,7 +131,7 @@ class LmomDistrMixin(object):
         return LmomFrozenDistr(self, *args, **kwds)
 
 
-class LmomFrozenDistr(scipy.stats.distributions.rv_frozen):
+class LmomFrozenDistr(rv_continuous_frozen):
     """
     Frozen version of the distribution returned by :class:`LmomDistrMixin`. Simply provides additional methods supported
     by the mixin.


### PR DESCRIPTION
Scipy 1.9, with its PR scipy/scipy#15794, introduced a split between the discrete and continuous versions of the  `rv_frozen` class It wasn't mentionned in the release notes I think, I am guessing they consider this API as private?

Anyway, this minor change solves the issue and makes `lmoments3` work with scipy 1.9 and above, without breaking it for previous versions.