### PR TITLE
Add moving notice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 lmoments3
 =========
 
+.. note::
+
+    The `lmoments3` project development has officially moved to https://github.com/Ouranosinc/lmoments3.
+    For any issues or pull requests (enhancements, bug fixes), please open them at the Ouranos fork.
+    This repository remains accessible for archival purposes.
+
 Python 3.x library to estimate linear moments for statistical distribution functions
 
 Requires the packages `numpy` and `scipy`.


### PR DESCRIPTION
@faph 

This is simply a notice for users to refer to the new location for the maintained fork. The last thing that could be done is to set the repository to `read-only` mode, and we can consider the project officially moved!